### PR TITLE
Fix calendar month overflow

### DIFF
--- a/src/views/CalendarView.ts
+++ b/src/views/CalendarView.ts
@@ -116,6 +116,9 @@ export class CalendarView extends ItemView {
   }
 
   private async navigate(delta: number) {
+    // Reset to the first of the month before changing the month to avoid
+    // JavaScript date overflow issues (e.g. Jan 31 -> Mar 2)
+    this.currentDate.setDate(1);
     this.currentDate.setMonth(this.currentDate.getMonth() + delta);
     await this.refreshEvents();
   }


### PR DESCRIPTION
## Summary
- prevent skipping months when navigating the calendar by resetting the date to day 1 before adjusting the month

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian' or its corresponding type declarations)*