### PR TITLE
Fix event loading when scrolling

### DIFF
--- a/src/views/CalendarView.ts
+++ b/src/views/CalendarView.ts
@@ -572,13 +572,13 @@ export class CalendarView extends ItemView {
 
     const { scrollTop, scrollHeight, clientHeight } = this.agenda;
 
-    // Load more past events when scrolling near the bottom
-    if (scrollTop + clientHeight >= scrollHeight - SCROLL_THRESHOLD) {
+    // Load more past events when scrolling near the top
+    if (scrollTop <= SCROLL_THRESHOLD) {
       await this.loadMorePastEvents();
     }
 
-    // Load more future events when scrolling near the top
-    if (scrollTop <= SCROLL_THRESHOLD) {
+    // Load more future events when scrolling near the bottom
+    if (scrollTop + clientHeight >= scrollHeight - SCROLL_THRESHOLD) {
       await this.loadMoreFutureEvents();
     }
   }


### PR DESCRIPTION
## Summary
- fix event load more conditions so previous events are loaded when scrolling up

## Testing
- `npm run build` *(fails: Cannot find module 'obsidian' or its type declarations)*