### PR TITLE
Add ICS file import via drag and drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ It showcases a list of your calendar events. When you click on an event, it crea
 2. A new note will be created automatically using your template
 3. The note will include event details like title, time, description, and location
 
+### Importing ICS Files
+
+You can import single-event ICS files directly:
+1. Drag and drop an ICS file onto the agenda view
+2. A note will be created for the event with all its details
+3. This is useful for quickly creating notes from meeting invitations or event exports
+
 ### Customizing Templates
 
 In the plugin settings, you can customize:

--- a/styles.css
+++ b/styles.css
@@ -398,3 +398,27 @@
     margin: 0 0.35rem;
   }
 }
+
+/* Drag and drop styles */
+.memochron-agenda.drag-over {
+  background-color: var(--background-modifier-hover);
+  border: 2px dashed var(--interactive-accent);
+  position: relative;
+}
+
+.memochron-agenda.drag-over::before {
+  content: "Drop ICS file here to create a note";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: var(--text-muted);
+  font-size: 1.2em;
+  font-weight: 600;
+  pointer-events: none;
+  z-index: 10;
+  background-color: var(--background-primary);
+  padding: 1em 2em;
+  border-radius: var(--radius-m);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}


### PR DESCRIPTION
## Summary
- Added drag and drop support for ICS files on the agenda view
- Users can now quickly create notes from meeting invitations by dropping ICS files

## Changes
- Implemented drag and drop event handlers in CalendarView
- Added ICS file parsing using the existing ical.js library
- Added visual feedback with hover state when dragging files
- Updated README with documentation for the new feature

## Test plan
- [ ] Drag an ICS file with a single event onto the agenda view
- [ ] Verify a note is created with all event details (title, time, location, description)
- [ ] Test error handling by dropping non-ICS files
- [ ] Test error handling by dropping ICS files with multiple events
- [ ] Verify visual feedback appears when hovering with a file

🤖 Generated with [Claude Code](https://claude.ai/code)