### PR TITLE
Add local calendar support with ICS file import

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ It showcases a list of your calendar events. When you click on an event, it crea
 2. A new note will be created automatically using your template
 3. The note will include event details like title, time, description, and location
 
+### Importing ICS Files
+
+You can import ICS files by dragging and dropping them onto the agenda view:
+
+1. Drag an ICS file onto the agenda area
+2. A local calendar called "Imported Calendar" will be created automatically
+3. For single-event ICS files:
+   - The event is added to the local calendar
+   - A note is automatically created for the event
+4. For multi-event ICS files:
+   - All events are added to the local calendar
+   - Notes can be created by clicking individual events
+
+Local calendars appear in your calendar list and can be toggled on/off like regular calendars.
+
 ### Customizing Templates
 
 In the plugin settings, you can customize:

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -94,12 +94,16 @@ export class SettingsTab extends PluginSettingTab {
     source: CalendarSource, 
     index: number
   ): TextComponent {
+    const isLocal = source.type === 'local';
     return text
-      .setPlaceholder("Calendar URL")
-      .setValue(source.url)
+      .setPlaceholder(isLocal ? "Local calendar (imported)" : "Calendar URL")
+      .setValue(isLocal ? `Local: ${source.localEvents?.length || 0} events` : source.url)
+      .setDisabled(isLocal)
       .onChange(async (value) => {
-        this.plugin.settings.calendarUrls[index].url = value;
-        await this.plugin.saveSettings();
+        if (!isLocal) {
+          this.plugin.settings.calendarUrls[index].url = value;
+          await this.plugin.saveSettings();
+        }
       });
   }
 

--- a/src/settings/types.ts
+++ b/src/settings/types.ts
@@ -16,6 +16,8 @@ export interface CalendarSource {
   name: string;
   enabled: boolean;
   tags: string[];
+  type?: 'url' | 'local'; // Default to 'url' for backward compatibility
+  localEvents?: any[]; // Store events directly for local calendars
 }
 
 export interface MemoChronSettings {

--- a/styles.css
+++ b/styles.css
@@ -398,3 +398,27 @@
     margin: 0 0.35rem;
   }
 }
+
+/* Drag and drop styles */
+.memochron-agenda.drag-over {
+  background-color: var(--background-modifier-hover);
+  border: 2px dashed var(--interactive-accent);
+  position: relative;
+}
+
+.memochron-agenda.drag-over::before {
+  content: "Drop ICS file here to import events";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: var(--text-muted);
+  font-size: 1.2em;
+  font-weight: 600;
+  pointer-events: none;
+  z-index: 10;
+  background-color: var(--background-primary);
+  padding: 1em 2em;
+  border-radius: var(--radius-m);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}


### PR DESCRIPTION
## Summary
- Implemented local calendar support for storing imported events
- Added drag-and-drop functionality for ICS files on the agenda view
- Automatic note creation for single-event ICS files

## Changes
- Extended `CalendarSource` type to support both URL-based and local calendars
- Added `parseIcsContent` and `addEventsToLocalCalendar` methods to CalendarService
- Implemented drag-and-drop handlers in CalendarView
- Updated SettingsTab to properly display local calendars
- Added visual feedback when dragging files

## How it works
1. Drag an ICS file onto the agenda view
2. A local calendar called "Imported Calendar" is created automatically
3. For single events: a note is created immediately
4. For multiple events: all are added to the calendar for later note creation
5. Local calendars can be toggled on/off like regular calendars

## Test plan
- [ ] Drag a single-event ICS file onto the agenda view
- [ ] Verify a note is created and the event appears in the calendar
- [ ] Drag a multi-event ICS file onto the agenda view  
- [ ] Verify all events are imported and appear in the calendar
- [ ] Check settings to see the local calendar with event count
- [ ] Toggle the local calendar on/off and verify events show/hide
- [ ] Test error handling with non-ICS files

🤖 Generated with [Claude Code](https://claude.ai/code)