### PR TITLE
Avoid overwriting existing event notes

### DIFF
--- a/src/views/CalendarView.ts
+++ b/src/views/CalendarView.ts
@@ -653,9 +653,12 @@ export class CalendarView extends ItemView {
       return;
     }
 
-    const file = await this.plugin.noteService.createEventNote(event);
+    let file = this.plugin.noteService.getExistingEventNote(event);
     if (!file) {
-      throw new Error("Failed to create or update note");
+      file = await this.plugin.noteService.createEventNote(event);
+      if (!file) {
+        throw new Error("Failed to create note");
+      }
     }
 
     const leaf = this.app.workspace.getLeaf("tab");

--- a/src/views/CalendarView.ts
+++ b/src/views/CalendarView.ts
@@ -654,11 +654,16 @@ export class CalendarView extends ItemView {
     }
 
     let file = this.plugin.noteService.getExistingEventNote(event);
+    const isNewNote = !file;
+    
     if (!file) {
       file = await this.plugin.noteService.createEventNote(event);
       if (!file) {
         throw new Error("Failed to create note");
       }
+      new Notice(`Created new note: ${file.basename}`);
+    } else {
+      new Notice(`Opened existing note: ${file.basename}`);
     }
 
     const leaf = this.app.workspace.getLeaf("tab");


### PR DESCRIPTION
## Summary
- Check for an existing note before creating a new one when an event is opened
- Add helper to lookup existing event notes by path
- Remove obsolete note-update logic so existing notes stay untouched
