### PR TITLE
fix: make agenda date header sticky when scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -824,10 +824,15 @@
 }
 
 .memochron-agenda-date-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   margin-top: var(--memochron-padding-md);
   margin-bottom: var(--memochron-padding-sm);
+  padding-top: var(--memochron-padding-sm);
   padding-bottom: var(--memochron-padding-xs);
   border-bottom: 1px solid var(--background-modifier-border);
+  background: var(--background-secondary);
   color: var(--text-muted);
   font-size: 0.95em;
   font-weight: 600;


### PR DESCRIPTION
Fixes #50

The date header now sticks to the top of the agenda scroll container, preventing events from 'popping out' above it.

**Changes:**
- Add `position: sticky` and `top: 0` to `.memochron-agenda-date-header`
- Add background color to prevent content showing through when scrolling
- Add z-index to ensure header stays above events
- Add padding-top for visual balance

**Before:** Date header scrolls away, events appear above where it was
**After:** Date header stays pinned at top until next date header pushes it away